### PR TITLE
Replace modal with external newsletter form link

### DIFF
--- a/src/lib/components/SubscribeBanner.tsx
+++ b/src/lib/components/SubscribeBanner.tsx
@@ -1,31 +1,33 @@
 "use client";
 import Image from "next/image";
-import ContactModal from "./ContactModal";
+import CloseIcon from "@/lib/assets/close.svg";
 import { useEffect, useState } from "react";
 import NewsletterBanner from "@/lib/assets/banners/newsletter.png";
+import ClientPortal from "./ClientPortal";
 
 export default function SubscribeBanner({ locale }: { locale: string }) {
-    const [showModal, setShowModal] = useState(false);
+    // const [showModal, setShowModal] = useState(false);
 
-    useEffect(() => {
-        if (showModal) {
-            document.body.style.overflow = "hidden";
-        } else {
-            document.body.style.overflow = "unset";
-        }
-    }, [showModal]);
+    // useEffect(() => {
+    //     if (showModal) {
+    //         document.body.style.overflow = "hidden";
+    //     } else {
+    //         document.body.style.overflow = "unset";
+    //     }
+    // }, [showModal]);
 
     return (
         <>
-            <ContactModal
+            {/* <ContactModal
                 title="subscribe-newsletter"
                 showTextInput={false}
                 showModal={showModal}
                 onClose={() => setShowModal(false)}
                 locale={locale}
-            ></ContactModal>
+            ></ContactModal> */}
+
             <button
-                onClick={() => setShowModal(true)}
+                onClick={() => window.open("https://forms.gle/uMQxTrwLCZurdF4j6", "_blank")}
                 className="Rectangle204 overflow-hidden bg-gradient-to-b from-emerald-300 to-emerald-300 rounded-2xl flex flex-col items-center justify-center"
             >
                 <Image


### PR DESCRIPTION
Commented out the ContactModal and related state logic in SubscribeBanner. The subscribe button now opens an external Google Forms link in a new tab instead of displaying a modal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Subscribe button in `SubscribeBanner` now opens a Google Form in a new tab; modal usage and related state/effects are disabled.
> 
> - **Frontend**
>   - **`src/lib/components/SubscribeBanner.tsx`**:
>     - Replace `ContactModal` interaction with opening an external Google Form on button click.
>     - Disable modal-related state and body scroll lock effect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57ed0cff8a267867370949e1040fd2bed1696f91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->