### PR TITLE
Comment out default tags filter in buildPostsQuery

### DIFF
--- a/src/app/[locale]/latest/data.ts
+++ b/src/app/[locale]/latest/data.ts
@@ -47,13 +47,14 @@ export function buildPostsQuery(tag?: string, query?: string, locale?: string) {
                 $eq: tag,
             },
         };
-    } else {
-        filters["tags"] = {
-            slug: {
-                $in: TAGS.map((t) => t.slug),
-            },
-        };
-    }
+    } 
+    // else {
+    //     filters["tags"] = {
+    //         slug: {
+    //             $in: TAGS.map((t) => t.slug),
+    //         },
+    //     };
+    // }
 
     if (locale && locale == "en") {
         filters["language"] = {
@@ -103,6 +104,8 @@ export async function fetchData({
     query?: string;
     locale?: string;
 }) {
+
+
     const tagRes = await getApi<any[]>(`/tags`, {
         populate: ["categories"],
         sort: ["title:asc"],


### PR DESCRIPTION
The default filter for tags using all TAGS slugs has been commented out in buildPostsQuery. This change may be intended to adjust the filtering logic when no specific tag is provided.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the default TAGS-based tag filter in buildPostsQuery so posts aren’t constrained by tags when no tag is specified.
> 
> - **Query logic**:
>   - In `src/app/[locale]/latest/data.ts` `buildPostsQuery`, disables the default `tags.slug in TAGS` filter (now commented out). Queries only apply tag/category constraints when a specific `tag` is provided.
>   - Language filter behavior unchanged; other changes are non-functional (formatting/comments).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b692a857cc39582948acada4d5d7b623b5ad2e29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->