### PR TITLE
Rename tag/ID to trainings-and-workshops

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -152,6 +152,7 @@
     "conspiracy-networks": "Conspiracy Networks",
     "resources-and-tools": "Resources and Tools",
     "what-we-are-reading": "Trainings and Workshops",
+    "trainings-and-workshops": "Trainings and Workshops",
     "additional-resources": "Additional Resources",
     "elections-and-voting": "Elections and Voting",
     "identity-and-culture": "Identity and Culture",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -152,6 +152,7 @@
     "conspiracy-networks": "Redes de Conspiración",
     "resources-and-tools": "Recursos y Herramientas",
     "what-we-are-reading": "Talleres y Eventos",
+    "trainings-and-workshops": "Talleres y Eventos",
     "additional-resources": "Recursos Adicionales",
     "elections-and-voting": "Elecciones y Votaciones",
     "identity-and-culture": "Identidad y Cultura",

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -152,6 +152,7 @@
     "conspiracy-networks": "Redes de Conspiração",
     "resources-and-tools": "Recursos e ferramentas",
     "what-we-are-reading": "Talleres e Eventos",
+    "trainings-and-workshops": "Talleres e Eventos",
     "additional-resources": "Recursos adicionais",
     "elections-and-voting": "Eleições e Votação",
     "identity-and-culture": "Identidade e Cultura",

--- a/src/app/[locale]/our-work/capacity-building.tsx
+++ b/src/app/[locale]/our-work/capacity-building.tsx
@@ -159,12 +159,12 @@ export default function CapacityBuilding({
                     </I18nLink>
 
                     <div
-                        id="what-we-are-reading"
+                        id="trainings-and-workshops"
                         className="flex flex-col lg:flex-row items-center gap-4 lg:gap-10 my-10 lg:my-20 w-full"
                     >
                         <div className="w-full lg:flex-1 h-[1px] bg-design-light bg-opacity-50"></div>
                         <div className="IntroductoryText text-center text-design-light text-3xl font-extrabold  leading-7">
-                            {t("what-we-are-reading")}
+                            {t("trainings-and-workshops")}
                         </div>
                         <div className="w-full lg:flex-1 h-[1px] bg-design-light bg-opacity-50"></div>
                     </div>
@@ -250,7 +250,7 @@ export default function CapacityBuilding({
 
                     {capacity.resourcesAndTools.whatWeAreReading.length > 0 && (
                         <I18nLink
-                            href={`/latest?tag=what-we-are-reading`}
+                            href={`/latest?tag=trainings-and-workshops`}
                             className="r-btn border-none text-white bg-design-green mt-10"
                         >
                             {t("see-all")}

--- a/src/app/[locale]/our-work/data.tsx
+++ b/src/app/[locale]/our-work/data.tsx
@@ -115,7 +115,7 @@ export async function fetchData(locale: string) {
             },
             tags: {
                 slug: {
-                    $eq: 'what-we-are-reading'
+                    $eq: 'trainings-and-workshops'
                 }
             },
             ...(locale && locale == "en" ? {

--- a/src/lib/components/navbar.tsx
+++ b/src/lib/components/navbar.tsx
@@ -249,8 +249,8 @@ export default function Navbar({ locale }: { locale: string }) {
                       >
                         {t("external-resources")}
                       </I18nLink>
-                      <I18nLink className="mt-2 text-white hover:text-[#6ABDC2] text-sm font-normal  uppercase leading-normal" href={"/our-work#what-we-are-reading"}>
-                        {t("what-we-are-reading")}
+                      <I18nLink className="mt-2 text-white hover:text-[#6ABDC2] text-sm font-normal  uppercase leading-normal" href={"/our-work#trainings-and-workshops"}>
+                        {t("trainings-and-workshops")}
                       </I18nLink>
                       <I18nLink
                         href={"/our-work#workshops-and-events"}
@@ -480,10 +480,10 @@ export default function Navbar({ locale }: { locale: string }) {
                   </I18nLink>
                   <I18nLink
                     onClick={onMobileNavbarClick}
-                    href={"/our-work#what-we-are-reading"}
+                    href={"/our-work#trainings-and-workshops"}
                     className="mt-2 text-white hover:text-[#6ABDC2] text-sm font-medium  uppercase leading-normal"
                   >
-                    {t("what-we-are-reading")}
+                    {t("trainings-and-workshops")}
                   </I18nLink>
                   <I18nLink
                     onClick={onMobileNavbarClick}


### PR DESCRIPTION
Replace usages of 'what-we-are-reading' with 'trainings-and-workshops'. Adds the new i18n key in en, es, and pt, updates the capacity-building component id and displayed label, changes the data fetch tag filter to 'trainings-and-workshops', and updates navbar links/anchors to point to /our-work#trainings-and-workshops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk string/anchor rename, but it can break deep links or content filtering if the backend/tag taxonomy isn’t updated in sync.
> 
> **Overview**
> Renames the Capacity-Building “What we are reading” section to **“Trainings and Workshops”** by switching the section anchor from `what-we-are-reading` to `trainings-and-workshops` and updating navbar links accordingly.
> 
> Updates data fetching and “See all” routing to use the `trainings-and-workshops` tag, and adds the new `trainings-and-workshops` i18n key in `en`/`es`/`pt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc52da1c9e346e45d9a29b00c82e41f461e771cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->