### PR TITLE
fix(docker): align Node and pnpm versions with CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:18-alpine AS base
+FROM node:22.13-alpine AS base
+RUN corepack enable && corepack prepare pnpm@11.1.3 --activate
 
 # 1. Install dependencies only when needed
 FROM base AS deps
@@ -12,7 +13,7 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json pnpm-lock.yaml* ./
-RUN yarn global add pnpm && pnpm i
+RUN pnpm install --frozen-lockfile
 
 
 # 2. Rebuild the source code only when needed
@@ -20,7 +21,7 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN npm run build
+RUN pnpm run build
 
 # 3. Production image, copy all the files and run next
 FROM base AS runner


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes CI Docker build failures caused by a Node/pnpm version mismatch.

The production workflow builds the app inside Docker. The image used `node:18-alpine` and installed the latest pnpm via `yarn global add pnpm`, which resolves to pnpm 11.x. pnpm 11 requires Node **>= 22.13**, while GitHub Actions uses pnpm **11.1.3**.

## Changes

- Pin base image to `node:22.13-alpine` (meets `>= 22.13`)
- Enable **pnpm 11.1.3** via Corepack (matches Actions)
- Replace `yarn global add pnpm` with `pnpm install --frozen-lockfile`
- Use `pnpm run build` in the builder stage

## Testing

- [ ] Production workflow Docker build passes on this branch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ed7eb44-fa5b-4512-bf52-c0636d956224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ed7eb44-fa5b-4512-bf52-c0636d956224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

