### PR TITLE
fix(docker): align Node/pnpm versions and fix Corepack keyid error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:22.13-alpine AS base
-RUN corepack enable && corepack prepare pnpm@11.1.3 --activate
+# Avoid Corepack keyid mismatch: bundled Corepack cannot verify current pnpm signatures.
+RUN npm install -g pnpm@11.1.3
 
 # 1. Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes CI Docker build failures.

## Problems fixed

1. **Node version**: Image used Node 18; pnpm 11 requires Node >= 22.13
2. **Corepack keyid**: `corepack prepare pnpm@11.1.3` failed with `Internal Error: Cannot find matching keyid` because bundled Corepack in the Node image cannot verify current pnpm signatures after npm registry key rotation

## Solution

- Base image: `node:22.13-alpine`
- Install pnpm **11.1.3** via `npm install -g pnpm@11.1.3` (matches Actions, avoids Corepack)
- `pnpm install --frozen-lockfile` and `pnpm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ed7eb44-fa5b-4512-bf52-c0636d956224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ed7eb44-fa5b-4512-bf52-c0636d956224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

